### PR TITLE
Fix changed JOSM Plugin API usage

### DIFF
--- a/josmplugin/src/sk/freemap/kapor/ExportPanel.java
+++ b/josmplugin/src/sk/freemap/kapor/ExportPanel.java
@@ -6,8 +6,8 @@ import java.awt.Event;
 import javax.swing.JPanel;
 
 import org.opengis.referencing.operation.TransformException;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 
 public class ExportPanel extends JPanel {
@@ -19,6 +19,7 @@ public class ExportPanel extends JPanel {
 		add("East", new Button("Budovy"));
 	}
 
+	@Override
 	public boolean action(Event evt, Object arg) {
 		try {
 			KatApplet map = KaporMenuActionListener.applet;
@@ -32,9 +33,9 @@ public class ExportPanel extends JPanel {
 			else
 				return false;
 
-			if (dataset.getNodes().size() > 0)
-				Main.getLayerManager().addLayer(new OsmDataLayer(dataset, OsmDataLayer.createNewName(), null));
-
+			if (dataset.getNodes().size() > 0) {
+				MainApplication.getLayerManager().addLayer(new OsmDataLayer(dataset, OsmDataLayer.createNewName(), null));
+			}
 			return true;
 
 		} catch (TransformException e) {

--- a/josmplugin/src/sk/freemap/kapor/KaporMenuActionListener.java
+++ b/josmplugin/src/sk/freemap/kapor/KaporMenuActionListener.java
@@ -5,7 +5,7 @@ import java.awt.event.ActionListener;
 
 import javax.swing.JFrame;
 
-import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.gui.MainApplication;
 
 public class KaporMenuActionListener implements ActionListener {
 
@@ -30,7 +30,7 @@ public class KaporMenuActionListener implements ActionListener {
 
 		frame.setVisible(true);
 
-		if (Main.map != null) {
+		if (MainApplication.getMap() != null) {
 			KaporZoomChangeListener.setAppletZoom();
 		}
 	}

--- a/josmplugin/src/sk/freemap/kapor/KaporPlugin.java
+++ b/josmplugin/src/sk/freemap/kapor/KaporPlugin.java
@@ -6,6 +6,7 @@ import javax.swing.JMenuItem;
 
 import org.opengis.referencing.FactoryException;
 import org.openstreetmap.josm.Main;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.NavigatableComponent;
 import org.openstreetmap.josm.gui.preferences.PreferenceSetting;
 import org.openstreetmap.josm.plugins.Plugin;
@@ -35,7 +36,7 @@ public class KaporPlugin extends Plugin implements PreferenceKeys {
 
 		JMenuItem menuItem = new JMenuItem("Kapor");
 		menuItem.addActionListener(new KaporMenuActionListener());
-		Main.main.menu.add(menuItem);
+		MainApplication.getMenu().add(menuItem);
 
 		NavigatableComponent
 				.addZoomChangeListener(new KaporZoomChangeListener());

--- a/josmplugin/src/sk/freemap/kapor/KaporZoomChangeListener.java
+++ b/josmplugin/src/sk/freemap/kapor/KaporZoomChangeListener.java
@@ -1,13 +1,14 @@
 package sk.freemap.kapor;
 
+import org.geotools.geometry.jts.JTS;
 import org.opengis.referencing.operation.TransformException;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.coor.EastNorth;
 import org.openstreetmap.josm.data.coor.LatLon;
+import org.openstreetmap.josm.gui.MainApplication;
+import org.openstreetmap.josm.gui.MapFrame;
+import org.openstreetmap.josm.gui.MapView;
 import org.openstreetmap.josm.gui.NavigatableComponent.ZoomChangeListener;
-
-import org.geotools.geometry.jts.JTS;
 
 import com.vividsolutions.jts.geom.Coordinate;
 
@@ -15,7 +16,7 @@ public class KaporZoomChangeListener implements ZoomChangeListener {
 
 	@Override
 	public void zoomChanged() {
-		if (Main.map != null && KaporMenuActionListener.applet != null
+		if (MainApplication.getMap() != null && KaporMenuActionListener.applet != null
 				&& KaporMenuActionListener.frame.isVisible()) {
 			KaporZoomChangeListener.setAppletZoom();
 		}
@@ -24,12 +25,14 @@ public class KaporZoomChangeListener implements ZoomChangeListener {
 	public static void setAppletZoom() {
 
 		KatApplet applet = KaporMenuActionListener.applet;
-		if (Main.map != null && applet != null) {
-			EastNorth center = Main.map.mapView.getCenter();
-			LatLon centerLatLon = Main.map.mapView.getProjection()
+		MapFrame map = MainApplication.getMap();
+		if (map != null && applet != null) {
+			MapView mapView = map.mapView;
+			EastNorth center = mapView.getCenter();
+			LatLon centerLatLon = mapView.getProjection()
 					.eastNorth2latlon(center);
 
-			Bounds b = Main.map.mapView.getRealBounds();
+			Bounds b = mapView.getRealBounds();
 			LatLon p1 = b.getMin(), p2 = b.getMax();
 
 			double x = centerLatLon.getX();

--- a/josmplugin/src/sk/freemap/kapor/PreferenceChangedListener.java
+++ b/josmplugin/src/sk/freemap/kapor/PreferenceChangedListener.java
@@ -1,11 +1,10 @@
 package sk.freemap.kapor;
 
+import org.openstreetmap.josm.spi.preferences.PreferenceChangeEvent;
+
 import sk.freemap.kapor.preferences.PreferenceKeys;
 
-import org.openstreetmap.josm.data.Preferences.PreferenceChangeEvent;
-
-public class PreferenceChangedListener implements
-		org.openstreetmap.josm.data.Preferences.PreferenceChangedListener, PreferenceKeys {
+public class PreferenceChangedListener implements org.openstreetmap.josm.spi.preferences.PreferenceChangedListener, PreferenceKeys {
 
 	@Override
 	public void preferenceChanged(PreferenceChangeEvent e) {

--- a/josmplugin/src/sk/freemap/kapor/preferences/KaporPreferenceSetting.java
+++ b/josmplugin/src/sk/freemap/kapor/preferences/KaporPreferenceSetting.java
@@ -14,8 +14,6 @@ import org.openstreetmap.josm.gui.preferences.DefaultTabPreferenceSetting;
 import org.openstreetmap.josm.gui.preferences.PreferenceTabbedPane;
 import org.openstreetmap.josm.tools.GBC;
 
-import sk.freemap.kapor.preferences.PreferenceKeys;
-
 public class KaporPreferenceSetting extends DefaultTabPreferenceSetting implements PreferenceKeys {
 	JCheckBox prefExportName;
 	
@@ -46,7 +44,7 @@ public class KaporPreferenceSetting extends DefaultTabPreferenceSetting implemen
 	 */
 	@Override
 	public boolean ok() {
-		Main.pref.put(FREEMAPKAPOR_EXPORT_NAME, prefExportName.isSelected());
+		Main.pref.putBoolean(FREEMAPKAPOR_EXPORT_NAME, prefExportName.isSelected());
 		return false;
 	}
 


### PR DESCRIPTION
Changes based on JOSM 13367 API,
Built .jar is in release

Summary of changes - all are for API usage by KaPor plugin:
- use MainApplication.getMap() instead of Main.map
- use MainApplication.getMenu() instead of Main.main
- use MainApplication.getLayerManager() instead of Main.getLayerManager()
- use new PreferenceChangedListener and PreferenceChangeEvent

Signed-off-by: Martin Karpisek <martin.karpisek@gmail.com>